### PR TITLE
Improve error reporting when processing bookmark destination

### DIFF
--- a/itext/src/main/java/com/itextpdf/text/pdf/SimpleBookmark.java
+++ b/itext/src/main/java/com/itextpdf/text/pdf/SimpleBookmark.java
@@ -244,6 +244,8 @@ public final class SimpleBookmark implements SimpleXMLDocHandler {
 	private static String makeBookmarkParam(PdfArray dest, IntHashtable pages)
 	{
 		StringBuffer s = new StringBuffer();
+		if (dest.size() == 0)
+			throw new IllegalArgumentException("Illegal bookmark destination");
 		PdfObject obj = dest.getPdfObject(0);
         if (obj.isNumber())
             s.append(((PdfNumber)obj).intValue() + 1);


### PR DESCRIPTION
When `makeBookmarkParam` is invoked with an empty `dest` array, fetching the first element without a guard will lead to an `IndexOutOfBoundsException` thrown by the underlying `ArrayList`. To prevent such obscure errors, we capture this illegal `dest` state and throw a more expressive exception instead.