### PR TITLE
Fix NPE when adding illegal child to nameless PdfLayer

### DIFF
--- a/itext/src/main/java/com/itextpdf/text/pdf/PdfLayer.java
+++ b/itext/src/main/java/com/itextpdf/text/pdf/PdfLayer.java
@@ -113,8 +113,13 @@ public class PdfLayer extends PdfDictionary implements PdfOCG {
      * @param child the child layer
      */
     public void addChild(PdfLayer child) {
-        if (child.parent != null)
-            throw new IllegalArgumentException(MessageLocalization.getComposedMessage("the.layer.1.already.has.a.parent", child.getAsString(PdfName.NAME).toUnicodeString()));
+        if (child.parent != null) {
+            String name = null;
+            PdfString pdfName = child.getAsString(PdfName.NAME);
+            if (pdfName != null)
+                name = pdfName.toUnicodeString();
+            throw new IllegalArgumentException(MessageLocalization.getComposedMessage("the.layer.1.already.has.a.parent", name));
+        }
         child.parent = this;
         if (children == null)
             children = new ArrayList<PdfLayer>();

--- a/pdfa/src/test/java/com/itextpdf/text/pdf/PdfA2CheckerTest.java
+++ b/pdfa/src/test/java/com/itextpdf/text/pdf/PdfA2CheckerTest.java
@@ -500,6 +500,13 @@ public class PdfA2CheckerTest {
         document.close();
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void layer_fixNPEOnAddChildThatAlreadyHasAParent() {
+        PdfLayer child = new PdfLayer("child");
+        new PdfLayer("parent").addChild(child);
+        new PdfLayer("new parent").addChild(child);
+    }
+
     @Test
     public void egsCheckTest1() throws DocumentException, IOException {
         Document document = new Document();


### PR DESCRIPTION
When a `PdfLayer` is created without a name, e.g., via `PdfLayer.createTitle()` or when reading OCProperties, and later a child that has already another parent is added to this layer, the `addChild(PdfLayer)` method throws a `NullPointerException`. The is because the name is retrieved and immediately converted to a Unicode string, even if it is `null`.

This problem was identified by our automated detector [MUDetect](https://github.com/stg-tud/MUDetect/). We would very much appreciate your feedback on our patch. Thank you very much!